### PR TITLE
Add config.template.json for slightly easier setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,10 @@
 # Currently Incomplete
 
 ## Setup
-1. **Add `./src/config.json`**
+1. **Configuration**
 
-It should look like this, but fill in the data
-```json
-{
-  "token": "DISCORD_TOKEN_GOES_HERE",
-  "sqlite_path": "PATH_TO_CDCLIENT.SQLITE",
-  "locale_path": "PATH_TO_LU_CLIENT\\client\\locale\\locale.xml",
-  "res_path": "PATH_TO_LU_CLIENT\\client\\res"
-}
-```
+Copy `src/config.template.json` to `src/config.json` and fill in the data.
+
 If you do not have a `cdclient.sqlite` check out [lcdr's utils](https://github.com/lcdr/utils) and use `./utils/fdb_to_sqlite.py` to convert the `cdclient.fdb` to `cdclient.sqlite`.
 
 2. Idk how someone is supposed to set up a TypeScript Project (if they transpile the files or i do or what), so good luck, I'll figure this out when it's in a usable state :)

--- a/src/config.template.json
+++ b/src/config.template.json
@@ -1,0 +1,7 @@
+{
+  "token": "DISCORD_TOKEN_GOES_HERE",
+  "sqlite_path": "PATH_TO_CDCLIENT.SQLITE",
+  "locale_path": "PATH_TO_LU_CLIENT/locale/locale.xml",
+  "res_path": "PATH_TO_LU_CLIENT/res",
+  "explorer_domain": "https://explorer.lu"
+}


### PR DESCRIPTION
This way you can just copy the file instead of manually copying the contents from the README and creating a new file. I've also added the explorer_domain option to that template file.
